### PR TITLE
feat(token extralist): add M and WrappedM tokens by M^0

### DIFF
--- a/src/sources/paraswap.extralist.json
+++ b/src/sources/paraswap.extralist.json
@@ -76,6 +76,14 @@
       "symbol": "USUAL",
       "decimals": 18,
       "logoURI": "https://assets.coingecko.com/coins/images/51091/standard/USUAL.jpg?1730035787"
+    },
+    {
+      "chainId": 1,
+      "address": "0x437cc33344a0B27A429f795ff6B469C72698B291",
+      "name": "WrappedM by M^0",
+      "symbol": "wM",
+      "decimals": 6,
+      "logoURI": "https://cdn.prod.website-files.com/6762be5b6c55f4c330bf115d/677d33de58eccf5acd737690_%24SmartM%20Ellipse-p-500.png"
     }
   ]
 }

--- a/src/sources/paraswap.extralist.json
+++ b/src/sources/paraswap.extralist.json
@@ -1,9 +1,9 @@
 {
   "name": "ParaSwap Extra Token List",
-  "timestamp": "2024-12-19T17:14:36.652Z",
+  "timestamp": "2025-02-19T14:02:29.126Z",
   "version": {
     "major": 1,
-    "minor": 2,
+    "minor": 3,
     "patch": 1
   },
   "logoURI": "https://cdn.paraswap.io/token/token.png",

--- a/src/sources/paraswap.extralist.json
+++ b/src/sources/paraswap.extralist.json
@@ -79,6 +79,14 @@
     },
     {
       "chainId": 1,
+      "address": "0x866A2BF4E572CbcF37D5071A7a58503Bfb36be1b",
+      "name": "M by M^0",
+      "symbol": "M",
+      "decimals": 6,
+      "logoURI": "https://cdn.prod.website-files.com/6762be5b6c55f4c330bf115d/677d33d0fe114dbb8219507d_%24M%20Ellipse-p-500.png"
+    },
+    {
+      "chainId": 1,
       "address": "0x437cc33344a0B27A429f795ff6B469C72698B291",
       "name": "WrappedM by M^0",
       "symbol": "wM",


### PR DESCRIPTION
Add M and WrappedM token (wM) to show up in ParaSwap UI

* M on Etherscan: https://etherscan.io/address/0x866A2BF4E572CbcF37D5071A7a58503Bfb36be1b
* WrappedM on Etherscan: https://etherscan.io/address/0x437cc33344a0B27A429f795ff6B469C72698B291
* M route path: https://github.com/paraswap/paraswap-dex-lib/pull/888
* wM route path https://github.com/paraswap/paraswap-dex-lib/pull/846

Do let us know if anything is required, 
Thanks