### PR TITLE
Add ZARO (Zaro Coin) — Ethereum, BNB Chain and Base

### DIFF
--- a/src/sources/chains.json
+++ b/src/sources/chains.json
@@ -5,5 +5,6 @@
     "137": "polygon",
     "250": "fantom",
     "42161": "arbitrum",
-    "43114": "avalanche"
+    "43114": "avalanche",
+    "8453": "base"
 }

--- a/src/sources/tokens/base.json
+++ b/src/sources/tokens/base.json
@@ -1,0 +1,10 @@
+[
+  {
+    "chainId": 8453,
+    "address": "0x1d4CeA73e212829d06B9a774d2e06be9DEe5AAB0",
+    "symbol": "ZARO",
+    "name": "Zaro Coin",
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/zarocoin/zarocoin/main/media/logos/ZARO_logo_2D.png"
+  }
+]

--- a/src/sources/tokens/bnb.json
+++ b/src/sources/tokens/bnb.json
@@ -2710,5 +2710,13 @@
     "name": "Capsule Coin",
     "decimals": 18,
     "logoURI": "https://assets.coingecko.com/coins/images/15921/standard/e55393fa-7b4d-40f5-9f36-9a8a6bdcb570.png?1696515534"
+  },
+  {
+    "chainId": 56,
+    "address": "0xa9D72F6C1490647DF20E8Fad3C136cA6AC42c2fc",
+    "symbol": "ZARO",
+    "name": "Zaro Coin",
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/zarocoin/zarocoin/main/media/logos/ZARO_logo_2D.png"
   }
 ]

--- a/src/sources/tokens/mainnet.json
+++ b/src/sources/tokens/mainnet.json
@@ -44502,7 +44502,7 @@
     "chainId": 1,
     "address": "0xEB9951021698B42e4399f9cBb6267Aa35F82D59D",
     "symbol": "LIF",
-    "name": "Líf",
+    "name": "L\u00c3\u00adf",
     "decimals": 18,
     "logoURI": "ipfs://QmQxgNR9yt7ctSvD7fhS6cLj7AMeoMM5rZE6mY7bZxc7ah"
   },
@@ -44729,5 +44729,13 @@
     "name": "ARBITRUM",
     "decimals": 18,
     "logoURI": "https://assets.coingecko.com/coins/images/16547/standard/photo_2023-03-29_21.47.00.jpeg?1696516109"
+  },
+  {
+    "chainId": 1,
+    "address": "0xc311FD6DA9686507F33991543d8158EF5FaDd5E7",
+    "symbol": "ZARO",
+    "name": "Zaro Coin",
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/zarocoin/zarocoin/main/media/logos/ZARO_logo_2D.png"
   }
 ]

--- a/src/sources/tokens/mainnet.json
+++ b/src/sources/tokens/mainnet.json
@@ -10613,7 +10613,7 @@
     "chainId": 1,
     "address": "0x9C38688E5ACB9eD6049c8502650db5Ac8Ef96465",
     "symbol": "LIF",
-    "name": "Líf",
+    "name": "Lif",
     "decimals": 18,
     "logoURI": "https://assets.coingecko.com/coins/images/1760/thumb/lif-logo.png?1622196538"
   },
@@ -44502,7 +44502,7 @@
     "chainId": 1,
     "address": "0xEB9951021698B42e4399f9cBb6267Aa35F82D59D",
     "symbol": "LIF",
-    "name": "L\u00c3\u00adf",
+    "name": "Líf",
     "decimals": 18,
     "logoURI": "ipfs://QmQxgNR9yt7ctSvD7fhS6cLj7AMeoMM5rZE6mY7bZxc7ah"
   },

--- a/src/sources/tokens/mainnet.json
+++ b/src/sources/tokens/mainnet.json
@@ -10613,7 +10613,7 @@
     "chainId": 1,
     "address": "0x9C38688E5ACB9eD6049c8502650db5Ac8Ef96465",
     "symbol": "LIF",
-    "name": "Lif",
+    "name": "Líf",
     "decimals": 18,
     "logoURI": "https://assets.coingecko.com/coins/images/1760/thumb/lif-logo.png?1622196538"
   },


### PR DESCRIPTION
## Add ZARO (Zaro Coin)

**Token:** Zaro Coin
**Symbol:** ZARO
**Decimals:** 18
**Website:** https://www.zarocoin.xyz
**CoinGecko:** https://www.coingecko.com/en/coins/zaro-coin

### Contracts

| Chain | Address |
|---|---|
| Ethereum (chainId 1) | `0xc311FD6DA9686507F33991543d8158EF5FaDd5E7` |
| BNB Chain (chainId 56) | `0xa9D72F6C1490647DF20E8Fad3C136cA6AC42c2fc` |
| Base (chainId 8453) | `0x1d4CeA73e212829d06B9a774d2e06be9DEe5AAB0` |

### Changes
- `src/sources/tokens/mainnet.json` — ZARO added (Ethereum)
- `src/sources/tokens/bnb.json` — ZARO added (BNB Chain)
- `src/sources/tokens/base.json` — ZARO added (Base, new file)
- `src/sources/chains.json` — Base chain (8453) registered so `base.json` is consumed by the build

The Base contract is an OptimismMintableERC20 deployed via the OP Stack Standard Bridge factory, bridged from the Ethereum mainnet contract.